### PR TITLE
Fix: Replace deprecated st.experimental_get_query_params with st.quer…

### DIFF
--- a/pyteamtv/_integrations/_streamlit.py
+++ b/pyteamtv/_integrations/_streamlit.py
@@ -10,12 +10,21 @@ def get_current_app(
     use_cache: bool = False,
     raise_on_missing_token: bool = True,
 ) -> App:
-    query_params = st.experimental_get_query_params()
+    # Use new st.query_params if available (Streamlit >= 1.30.0),
+    # otherwise fall back to experimental API
+    if hasattr(st, "query_params"):
+        # New API: st.query_params returns a dict-like object
+        query_params = st.query_params
+        token = query_params.get("token", None)
+    else:
+        # Old API: st.experimental_get_query_params returns dict with list values
+        query_params = st.experimental_get_query_params()
+        token = query_params.get("token", [None])[0]
 
     return _get_current_app(
         app_id=app_id,
         session=st.session_state,
-        token=query_params.get("token", [None])[0],
+        token=token,
         use_cache=use_cache,
         raise_on_missing_token=raise_on_missing_token,
     )

--- a/tests/test_to_kloppy.py
+++ b/tests/test_to_kloppy.py
@@ -1,0 +1,120 @@
+from datetime import timedelta
+from pyteamtv.models.observation import Observation
+from pyteamtv.models.observation_log import ObservationLog
+from pyteamtv.models.sporting_event import SportingEvent
+
+
+def test_to_kloppy(requester, requests_mock):
+    """Test that to_kloppy converts observations to kloppy CodeDataset with period parsing."""
+    sporting_event = SportingEvent(
+        requester,
+        {
+            "sportingEventId": "event-1",
+            "type": "match",
+            "name": "Team A - Team B",
+            "scheduledAt": "2025-01-01T10:00:00Z",
+            "homeTeamId": "team-1",
+            "awayTeamId": "team-2",
+            "lineUpId": "lineup-1",
+            "clocks": {},
+            "outcome": {"score": {"home": 1, "away": 10}},
+        },
+    )
+
+    requests_mock.get(
+        "https://fake-url/sportingEvents/event-1/observations/U1",
+        json=[
+            {
+                "observationId": "1",
+                "code": "CUSTOM",
+                "description": "start",
+                "startTime": 100.0,
+                "endTime": 101.0,
+                "triggerTime": 100.0,
+                "clockId": "clock-1",
+                "attributes": {"code": "start", "labels": [{"text": "start"}]},
+            },
+            {
+                "observationId": "2",
+                "code": "CUSTOM",
+                "description": "BS2 TEAM1",
+                "startTime": 110.0,
+                "endTime": 115.0,
+                "triggerTime": 110.0,
+                "clockId": "clock-1",
+                "attributes": {"code": "BS2 TEAM1", "labels": [{"text": "BS2 TEAM1"}]},
+            },
+            {
+                "observationId": "3",
+                "code": "CUSTOM",
+                "description": "eind",
+                "startTime": 900.0,
+                "endTime": 901.0,
+                "triggerTime": 900.0,
+                "clockId": "clock-1",
+                "attributes": {"code": "eind", "labels": [{"text": "eind"}]},
+            },
+            {
+                "observationId": "4",
+                "code": "CUSTOM",
+                "description": "start",
+                "startTime": 1000.0,
+                "endTime": 1001.0,
+                "triggerTime": 1000.0,
+                "clockId": "clock-1",
+                "attributes": {"code": "start", "labels": [{"text": "start"}]},
+            },
+            {
+                "observationId": "5",
+                "code": "CUSTOM",
+                "description": "GOAL TEAM1",
+                "startTime": 1150.0,
+                "endTime": 1155.0,
+                "triggerTime": 1150.0,
+                "clockId": "clock-1",
+                "attributes": {
+                    "code": "GOAL TEAM1",
+                    "labels": [{"text": "GOAL TEAM1"}],
+                },
+            },
+            {
+                "observationId": "6",
+                "code": "CUSTOM",
+                "description": "eind",
+                "startTime": 1900.0,
+                "endTime": 1901.0,
+                "triggerTime": 1900.0,
+                "clockId": "clock-1",
+                "attributes": {"code": "eind", "labels": [{"text": "eind"}]},
+            },
+        ],
+    )
+
+    observation_log = ObservationLog(
+        Observation,
+        requester,
+        "GET",
+        "/sportingEvents/event-1/observations/U1",
+        "clock-1",
+        sporting_event,
+    )
+
+    # Call to_kloppy
+    dataset = sporting_event.to_kloppy()
+
+    # Assertions
+    assert len(dataset.metadata.periods) == 2
+    assert dataset.metadata.periods[0].id == 1
+    assert dataset.metadata.periods[1].id == 2
+
+    # Check that records have periods assigned and timestamps are normalized
+    assert len(dataset.records) == 6
+    assert dataset.records[1].code == "BS2 TEAM1"
+    assert dataset.records[1].period.id == 1
+    assert dataset.records[1].timestamp == timedelta(seconds=10.0)  # 110 - 100 = 10
+    assert dataset.records[4].code == "GOAL TEAM1"
+    assert dataset.records[4].period.id == 2
+    assert dataset.records[4].timestamp == timedelta(seconds=150.0)  # 1150 - 1000 = 150
+
+    assert dataset.metadata.score.home == 1
+    assert dataset.metadata.score.away == 10


### PR DESCRIPTION
…y_params

- Replace st.experimental_get_query_params with st.query_params (Streamlit >= 1.30.0)
- Maintain backward compatibility using hasattr check
- Add test for to_kloppy() method

The experimental API will be removed after 2024-04-11, this change ensures compatibility with newer Streamlit versions while maintaining support for older versions.